### PR TITLE
fix formio/text-field-apperance

### DIFF
--- a/projects/angular-material-formio/src/lib/components/textfield/textfield.component.ts
+++ b/projects/angular-material-formio/src/lib/components/textfield/textfield.component.ts
@@ -41,7 +41,7 @@ export class MaterialTextfieldComponent extends MaterialComponent {
   getFormFieldAppearance() {
     const appearances = ['legacy', 'standard', 'fill', 'outline'];
     const appearance = this.instance.component.appearance ? this.instance.component.appearance.toLowerCase() : '';
-    return appearances.includes(appearance) ? appearance : 'legacy';
+    return appearances.includes(appearance) ? appearance : undefined;
   }
 }
 TextFieldComponent.MaterialComponent = MaterialTextfieldComponent;


### PR DESCRIPTION
Since it is possible to set the default appearance globally adding a provider in in the app.module. for example 
`providers: [
    {
      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
      useValue: {appearance: 'outline'}
    }
    // ... other providers like services
  ]`

before my change the global option was overwritten by legacy, that's why I'm changing to return undefined in the case it is not set.

So now the behavior is the following set to undefined when not set or the given option

