### PR TITLE
Fix(Slect, Radio): error messages are not shown

### DIFF
--- a/projects/angular-material-formio/src/lib/components/MaterialComponent.ts
+++ b/projects/angular-material-formio/src/lib/components/MaterialComponent.ts
@@ -34,11 +34,17 @@ export class MaterialComponent implements AfterViewInit, OnInit {
   renderComponents() {}
 
   onChange() {
+    let value = this.getValue();
+
+    if (value === undefined || value === null) {
+      value = this.instance.emptyValue;
+    }
+
     if (this.input && this.input.nativeElement.mask) {
-      this.input.nativeElement.mask.textMaskInputElement.update(this.getValue());
+      this.input.nativeElement.mask.textMaskInputElement.update(value);
       this.control.setValue(this.input.nativeElement.value);
     }
-    this.instance.updateValue(this.getValue(), {modified: true});
+    this.instance.updateValue(value, {modified: true});
   }
 
   getValue() {

--- a/projects/angular-material-formio/src/lib/components/radio/radio.component.ts
+++ b/projects/angular-material-formio/src/lib/components/radio/radio.component.ts
@@ -16,7 +16,13 @@ import RadioComponent from 'formiojs/components/radio/Radio.js';
         fxFlexOffset="10px"
         fxLayout="{{ getLayout() }}"
         fxLayoutGap="10px">
-        <mat-radio-button *ngFor="let option of instance.component.values" value="{{ option.value }}" [checked]="isRadioChecked(option)">{{ option.label }}</mat-radio-button>
+        <mat-radio-button *ngFor="let option of instance.component.values"
+                          value="{{ option.value }}"
+                          [checked]="isRadioChecked(option)"
+        >
+          {{ option.label }}
+        </mat-radio-button>
+        <mat-error *ngIf="instance.error">{{ instance.error.message }}</mat-error>
       </mat-radio-group>
     </div>
   `

--- a/projects/angular-material-formio/src/lib/components/select/select.component.ts
+++ b/projects/angular-material-formio/src/lib/components/select/select.component.ts
@@ -8,7 +8,6 @@ import SelectComponent from 'formiojs/components/select/Select.js';
       <mat-label>{{ instance.component.label }}</mat-label>
       <span *ngIf="instance.component.prefix" matPrefix>{{ instance.component.prefix }}&nbsp;</span>
       <mat-select
-        [required]="instance.component.validate?.required"
         [multiple]="instance.component.multiple"
         [formControl]="control"
         [placeholder]="instance.component.placeholder"

--- a/projects/angular-material-formio/src/lib/components/textarea/textarea.component.ts
+++ b/projects/angular-material-formio/src/lib/components/textarea/textarea.component.ts
@@ -11,11 +11,11 @@ import isNil from 'lodash/isNil';
       <mat-label fxFill>{{ instance.component.label }}</mat-label>
       <span *ngIf="instance.component.prefix" matPrefix>{{ instance.component.prefix }}&nbsp;</span>
       <textarea matInput
-          [required]="instance.component.validate?.required"
           [placeholder]="instance.component.placeholder"
           [formControl]="control"
           [rows]="(instance.component.rows || 3)"
-          (input)="onChange()" #textarea>
+          (input)="onChange()" #textarea
+      >
       </textarea>
       <span *ngIf="instance.component.suffix" matSuffix>{{ instance.component.suffix }}</span>
       <mat-icon *ngIf="instance.component.tooltip" matSuffix matTooltip="{{ instance.component.tooltip }}">info</mat-icon>

--- a/projects/angular-material-formio/src/lib/components/textfield/textfield.component.ts
+++ b/projects/angular-material-formio/src/lib/components/textfield/textfield.component.ts
@@ -7,10 +7,11 @@ export const TEXTFIELD_TEMPLATE = `
     <span *ngIf="instance.component.prefix && instance.type !== 'currency'" matPrefix>{{ instance.component.prefix }}&nbsp;</span>
     <input matInput
            type="{{ inputType }}"
-           [required]="instance.component.validate?.required"
            [formControl]="control"
            [placeholder]="instance.component.placeholder"
-           (input)="onChange()" #input>
+           (input)="onChange()"
+            #input
+           >
     <span *ngIf="instance.component.suffix" matSuffix>{{ instance.component.suffix }}</span>
     <mat-icon *ngIf="instance.component.tooltip" matSuffix matTooltip="{{ instance.component.tooltip }}">info</mat-icon>
     <mat-hint *ngIf="instance.component.showWordCount">


### PR DESCRIPTION
Removed 'required' attribute, beacause we can simply use our core validator which is adapted for formio components and their settings