### PR TITLE
Fix (DateTime): The control doesn't show up any datetime

### DIFF
--- a/projects/angular-material-formio/src/lib/components/date/date.component.ts
+++ b/projects/angular-material-formio/src/lib/components/date/date.component.ts
@@ -104,6 +104,10 @@ export class MaterialDateComponent extends MaterialComponent {
 
   setValue(value) {
     if (this.dateFilter(value) && this.checkMinMax(value)) {
+      if (value) {
+        const format = `YYYY-MM-DD${this.instance.component.enableTime ? 'THH:mm' : ''}`;
+        value = momentDate(value).format(format)
+       }
       super.setValue(value);
     }
   }


### PR DESCRIPTION
The control doesn't show up any DateTime on load if the submission has some DateTime as an input to the form.