### PR TITLE
delete empty mat-option,

### DIFF
--- a/projects/angular-material-formio/src/lib/components/select/select.component.ts
+++ b/projects/angular-material-formio/src/lib/components/select/select.component.ts
@@ -24,7 +24,6 @@ import SelectComponent from 'formiojs/components/select/Select.js';
           <div class="mat-option">
             <input class="mat-input-element" placeholder="Type to search" (input)="onFilter($event.target.value)">
           </div>
-          <mat-option></mat-option>
           <mat-option *ngIf="!filteredOptionsLength" disabled>
             <span>Nothing was found</span>
           </mat-option>


### PR DESCRIPTION
which was creating an empty option in the dropdowns.
This PR will solve this issue https://github.com/formio/angular-material-formio/issues/140