### PR TITLE
Fix selected option in select for json dataSrc

### DIFF
--- a/projects/angular-material-formio/src/lib/components/select/select.component.ts
+++ b/projects/angular-material-formio/src/lib/components/select/select.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { MaterialComponent } from '../MaterialComponent';
 import SelectComponent from 'formiojs/components/select/Select.js';
+import _ from 'lodash';
 @Component({
   selector: 'mat-formio-select',
   template: `
@@ -20,6 +21,7 @@ import SelectComponent from 'formiojs/components/select/Select.js';
                 [formControl]="control"
                 [placeholder]="instance.component.placeholder"
                 (selectionChange)="onChange()"
+                [compareWith]="compareObjects"
         >
           <div class="mat-option">
             <input class="mat-input-element" placeholder="Type to search" (input)="onFilter($event.target.value)">
@@ -45,7 +47,7 @@ export class MaterialSelectComponent extends MaterialComponent implements OnInit
   selectOptions: Promise<any[]>;
   filteredOptions: Promise<any[]>;
   filteredOptionsLength: number;
-
+  
   selectOptionsResolve: any;
 
   setInstance(instance: any) {
@@ -70,6 +72,10 @@ export class MaterialSelectComponent extends MaterialComponent implements OnInit
       this.filteredOptionsLength = filtered.length;
       return filtered;
     })
+  }
+
+  compareObjects(o1: any, o2: any): boolean {
+    return _.isEqual(o1, o2);
   }
 }
 SelectComponent.MaterialComponent = MaterialSelectComponent;


### PR DESCRIPTION
use compareWith option from the angular mat-slect component to be able to set the selected option
when the option is an object

link to the compareWith documentation https://material.angular.io/components/select/api#MatSelect

Having something like the code below, the default value was not selected

`{
  "components": [
    {
      "label": "Select",
      "widget": "choicesjs",
      "tableView": true,
      "dataSrc": "json",
      "valueProperty": "",
      "defaultValue": {
                "rangeType": "p",
                "name": "Married",
                "active": true,
                "intlId": "married",
                "id": 102,
                "userId": "M"
      },
      "data": {
        "json": [
          {
            "rangeType": "p",
            "name": "Separated",
            "intlId": "separated",
            "active": true,
            "id": 106,
            "userId": "S"
          },
          {
            "rangeType": "p",
            "name": "Married",
            "active": true,
            "intlId": "married",
            "id": 102,
            "userId": "M"
          },
        ]
      },
      "template": "<span>{{ item.name }}</span>",
      "selectThreshold": 0.3,
      "key": "maritalStatus",
      "type": "select",
      "indexeddb": {
        "filter": {}
      },
      "input": true
    }`

